### PR TITLE
chore: gitleaks:allow a false positive finding

### DIFF
--- a/tests/test_responsegenerator.py
+++ b/tests/test_responsegenerator.py
@@ -56,7 +56,7 @@ async def test_generator(monkeypatch):
     )
 
     cost = await generator_object.estimate_token_cost(
-        tiktoken_model_name="gpt-3.5-turbo-16k-0613",
+        tiktoken_model_name="gpt-3.5-turbo-16k-0613", #gitleaks:allow
         prompts=MOCKED_DUPLICATE_PROMPTS,
         example_responses=MOCKED_RESPONSES[:3],
         count=count,


### PR DESCRIPTION
## Description

When running `gitleaks dir -v` against the main branch, a single warning is generated:

```
langfair git:(main) ✗ gitleaks dir -v

    ○
    │╲
    │ ○
    ○ ░
    ░    gitleaks

Finding:     tiktoken_model_name="gpt-3.5-turbo-16k-0613"
Secret:      gpt-3.5-turbo-16k-0613
RuleID:      generic-api-key
Entropy:     3.732159
File:        tests/test_responsegenerator.py
Line:        59
Fingerprint: tests/test_responsegenerator.py:generic-api-key:59
```

Adding the trailing comment ` #gitleaks:allow` results in no warnings.

## Contributor License Agreement
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [X] confirm you have signed the [LangFair CLA](https://forms.office.com/pages/responsepage.aspx?id=uGG7-v46dU65NKR_eCuM1xbiih2MIwxBuRvO0D_wqVFUMlFIVFdYVFozN1BJVjVBRUdMUUY5UU9QRS4u&route=shorturl)

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [X] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [X] no documentation changes needed
- [ ] README updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots

N/A