### PR TITLE
chore: add trivy for SCA

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,14 +72,33 @@ jobs:
       - name: Run ruff checks
         run: poetry run ruff check
 
-      - name: Install snyk
-        uses: snyk/actions/setup@86b1cee1b8e110a78d528b3e1328a80e218111d2
+  trivy:
+    name: trivy/ci
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
         with:
-          snyk-version: v1.1298.3
-      # - name: Run snyk test
-      #   run: snyk test --file=poetry.lock --package-manager=pip --fail-on=upgradable
-      #   env:
-      #     SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          persist-credentials: false
+      - name: Run trivy vulnerability scan
+        uses: aquasecurity/trivy-action@dc5a429b52fcf669ce959baa2c2dd26090d2a6c4
+        with:
+          format: sarif
+          output: "trivy-results.sarif"
+          scan-type: 'fs'
+          scan-ref: '.'
+          trivy-config: trivy.yaml
+      - name: Save SARIF results as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: trivy-scan-results
+          path: "trivy-results.sarif"
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: "trivy-results.sarif"
 
   semgrep:
     name: semgrep/ci

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -1,0 +1,10 @@
+# Trivy configuration file
+exit-code: 1
+pkg:
+  include-dev-deps: true
+scan:
+  scanners:
+    - vuln
+    # - secret - disable because the project uses gitleaks
+vulnerability:
+  ignore-unfixed: true


### PR DESCRIPTION
## Description

This adds SCA scanning in the CI workflow using [trivy](https://trivy.dev/latest/docs/target/filesystem/). Basic configuration of the scanner is stored in-repo in `trivy.yaml` so any contributor can run locally with the same settings used in CI. No authentication is required either by contributors running the scanner locally or by the CI process.

Running locally: `brew install trivy` and `trivy fs .` produces

```
2025-08-20T22:12:11-04:00       INFO    Loaded  file_path="trivy.yaml"
2025-08-20T22:12:11-04:00       INFO    [vuln] Vulnerability scanning is enabled
2025-08-20T22:12:11-04:00       INFO    Number of language-specific files       num=1
2025-08-20T22:12:11-04:00       INFO    [poetry] Detecting vulnerabilities...

Report Summary

┌─────────────┬────────┬─────────────────┐
│   Target    │  Type  │ Vulnerabilities │
├─────────────┼────────┼─────────────────┤
│ poetry.lock │ poetry │        0        │
└─────────────┴────────┴─────────────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)
```
and exits 0.

When a vulnerability is found that can be resolved with a dependency update, the report will include details on the vulnerability and fix version(s).

When CI runs the scan, it produces a `sarif` format report and uploads that to GitHub. GitHub processes those uploads and stores the data as code scanning results. These show up in the Checks tab of the PR

<img width="814" height="654" alt="Screenshot 2025-08-20 at 10 18 29 PM" src="https://github.com/user-attachments/assets/a01f7e62-fd48-4a7a-a783-27f2e2e2f0e5" />

and are also stored as Code Scanning "vulnerability alerts" in the Security tab, see https://github.com/trumant/langfair/security/code-scanning

One maintainer benefit is that this allows tracking issue disposition, i.e. issues can be tracked with clear "will not fix" status as in https://github.com/trumant/langfair/security/code-scanning/1

### Integrating Trivy into pre-commit

There is pre-existing work in the community to do so and Trivy can be run from either local install or via container image.
If this proves appealing, the PR will need to have additional work done to add the docs and relevant pre-commit configuration updates.

### Integrating Trivy into CI

Running the scans in the upstream repository will not require any secret setup. Maintainers should familiarize themselves with https://docs.github.com/en/code-security/code-scanning/managing-code-scanning-alerts/triaging-code-scanning-alerts-in-pull-requests to understand what 



## Contributor License Agreement
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [ ] confirm you have signed the [LangFair CLA](https://forms.office.com/pages/responsepage.aspx?id=uGG7-v46dU65NKR_eCuM1xbiih2MIwxBuRvO0D_wqVFUMlFIVFdYVFozN1BJVjVBRUdMUUY5UU9QRS4u&route=shorturl)

## Tests
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [ ] no new tests required
- [ ] new tests added
- [ ] existing tests adjusted

## Documentation
<!--- Select all that apply by putting an x between the brackets: [x] -->
- [ ] no documentation changes needed
- [ ] README updated
- [ ] API docs added or updated
- [ ] example notebook added or updated

## Screenshots
<!--- If applicable, please add screenshots. -->